### PR TITLE
Throw StreamNotFoundException instead of letting the LINQ Single() th…

### DIFF
--- a/Source/Streamstone.Tests/Scenarios/Reading_from_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Reading_from_stream.cs
@@ -29,7 +29,14 @@ namespace Streamstone.Scenarios
             Assert.Throws<ArgumentOutOfRangeException>(
                 async ()=> await Stream.ReadAsync<TestEventEntity>(partition, -1));
         }
-        
+
+        [Test]
+        [ExpectedException(typeof(StreamNotFoundException))]
+        public async void When_stream_doesnt_exist()
+        {
+            await Stream.ReadAsync<TestEventEntity>(partition);
+        }
+
         [Test]
         public async void When_stream_is_empty()
         {

--- a/Source/Streamstone/Stream.Operations.cs
+++ b/Source/Streamstone/Stream.Operations.cs
@@ -531,7 +531,14 @@ namespace Streamstone
 
             DynamicTableEntity FindStreamEntity(IEnumerable<DynamicTableEntity> entities)
             {
-                return entities.Single(x => x.RowKey == partition.StreamRowKey());
+                var result = entities.SingleOrDefault(x => x.RowKey == partition.StreamRowKey());
+
+                if (result == null)
+                {
+                    throw new StreamNotFoundException(partition.Table, partition);
+                }
+
+                return result;
             }
 
             Stream BuildStream(DynamicTableEntity entity)


### PR DESCRIPTION
…row InvalidOperationException when the key is not found.
