### PR TITLE
Fixing example project

### DIFF
--- a/Source/Example/Program.cs
+++ b/Source/Example/Program.cs
@@ -30,17 +30,19 @@ namespace Example
 
             for (int i = 0; i < scenarios.Length; i++)
             {
-                var scenario = scenarios[i];
 
-                Console.WriteLine("{0}", scenario.GetType().Name.Replace("_", " "));
+                var scenario = scenarios[i];
+	            var scenarioName = scenario.GetType().Name;
+
+                Console.WriteLine("{0}", scenarioName.Replace("_", " "));
                 Console.WriteLine(new string('-', 40));
 
-                scenario.Initialize(table, i.ToString());
+                scenario.Initialize(table, scenarioName);
                 scenario.Run();
 
                 Console.WriteLine();
             }
-            Console.WriteLine("You can check out the contents of Example table using Server Explorer in VS");
+            Console.WriteLine(string.Format("You can check out the contents of '{0}' table using Server Explorer in VS", table.Name));
             Console.WriteLine("Press any key to exit ...");
 
             Console.ReadKey(true);

--- a/Source/Example/Scenarios/S04_Write_to_stream.cs
+++ b/Source/Example/Scenarios/S04_Write_to_stream.cs
@@ -67,7 +67,7 @@ namespace Example.Scenarios
             Enumerable.Range(1, streamsToWrite).AsParallel()
                 .ForAll(streamIndex =>
                 {
-                    var partition = new Partition(Partition.Table, streamIndex.ToString());
+                    var partition = new Partition(Partition.Table, $"WriteMultipleStreamsInParallel-{streamIndex}");
 
                     var existent = Stream.TryOpen(partition);
 

--- a/Source/Example/Scenarios/S05_Read_from_stream.cs
+++ b/Source/Example/Scenarios/S05_Read_from_stream.cs
@@ -22,7 +22,9 @@ namespace Example.Scenarios
                 .Select(Event)
                 .ToArray();
 
-            Stream.Write(new Stream(Partition), events);
+            var existent = Stream.TryOpen(Partition);
+	        var stream = existent.Found ? existent.Stream : new Stream(Partition);
+	        Stream.Write(stream, events);
         }
 
         void ReadSlice()

--- a/Source/Example/Scenarios/S05_Read_from_stream.cs
+++ b/Source/Example/Scenarios/S05_Read_from_stream.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Microsoft.WindowsAzure.Storage.Table;
 using Streamstone;
 
 namespace Example.Scenarios

--- a/Source/Example/Scenarios/S05_Read_from_stream.cs
+++ b/Source/Example/Scenarios/S05_Read_from_stream.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-
+using Microsoft.WindowsAzure.Storage.Table;
 using Streamstone;
 
 namespace Example.Scenarios
@@ -72,7 +72,7 @@ namespace Example.Scenarios
 
         class EventEntity
         {
-            public string Id   { get; set; }
+            public int Id { get; set; }
             public string Type { get; set; }
             public string Data { get; set; }
             public int Version { get; set; }

--- a/Source/Example/Scenarios/S06_Include_additional_entities.cs
+++ b/Source/Example/Scenarios/S06_Include_additional_entities.cs
@@ -12,7 +12,8 @@ namespace Example.Scenarios
     {
         public override void Run()
         {
-            var stream = new Stream(Partition);
+            var existent = Stream.TryOpen(Partition);
+	        var stream = existent.Found ? existent.Stream : new Stream(Partition);
 
             Console.WriteLine("Writing to new stream along with making snapshot in partition '{0}'", 
                               stream.Partition);


### PR DESCRIPTION
Fixed couple of initialization issues with Example project - so the test scenarios can run end to end without conflicts. Prettified table output - Sample table content is more readable.
