### PR TITLE
InsertOrMerge operation provided for Includes

### DIFF
--- a/Source/Streamstone/EntityOperation.cs
+++ b/Source/Streamstone/EntityOperation.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 using System.Linq;
-
+using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone
 {
     abstract class EntityOperation
     {
-        public static readonly EntityOperation None = new Null(); 
+        public static readonly EntityOperation None = new Null();
 
         public readonly ITableEntity Entity;
-        
+
         EntityOperation(ITableEntity entity)
         {
             Entity = entity;
@@ -27,8 +27,8 @@ namespace Streamstone
 
         Exception InvalidMerge(EntityOperation other)
         {
-            var message = string.Format("Included '{0}' operation cannot be followed by '{1}' operation", 
-                                        GetType().Name, other.GetType().Name);
+            var message = string.Format("Included '{0}' operation cannot be followed by '{1}' operation",
+                GetType().Name, other.GetType().Name);
 
             return new InvalidOperationException(message);
         }
@@ -43,7 +43,8 @@ namespace Streamstone
         {
             public Insert(ITableEntity entity)
                 : base(entity)
-            {}
+            {
+            }
 
             protected override TableOperation AsTableOperation()
             {
@@ -52,14 +53,20 @@ namespace Streamstone
 
             public override EntityOperation Merge(EntityOperation other)
             {
-                if (other is Insert) 
+                if (other is Insert)
                     throw InvalidMerge(other);
-                
-                if (other is Replace) 
+
+                if (other is Replace)
                     return new Insert(other.Entity);
 
-                if (other is Delete) 
+                if (other is Delete)
                     return None;
+
+                if (other is InsertOrMerge)
+                    throw InvalidMerge(other);
+
+                if (other is InsertOrReplace)
+                    throw InvalidMerge(other);
 
                 throw new InvalidOperationException("Unsupported operation type: " + other.GetType());
             }
@@ -69,7 +76,8 @@ namespace Streamstone
         {
             public Replace(ITableEntity entity)
                 : base(entity)
-            {}
+            {
+            }
 
             protected override TableOperation AsTableOperation()
             {
@@ -87,15 +95,22 @@ namespace Streamstone
                 if (other is Delete)
                     return other;
 
+                if (other is InsertOrMerge)
+                    throw InvalidMerge(other);
+
+                if (other is InsertOrReplace)
+                    throw InvalidMerge(other);
+
                 throw new InvalidOperationException("Unsupported operation type: " + other.GetType());
             }
         }
-        
+
         public class Delete : EntityOperation
         {
             public Delete(ITableEntity entity)
                 : base(entity)
-            {}
+            {
+            }
 
             protected override TableOperation AsTableOperation()
             {
@@ -113,15 +128,88 @@ namespace Streamstone
                 if (other is Delete)
                     throw InvalidMerge(other);
 
+                if (other is InsertOrMerge)
+                    throw InvalidMerge(other);
+
+                if (other is InsertOrReplace)
+                    throw InvalidMerge(other);
+
+                throw new InvalidOperationException("Unsupported operation type: " + other.GetType());
+            }
+        }
+
+        public class InsertOrMerge : EntityOperation
+        {
+            public InsertOrMerge(ITableEntity entity)
+                : base(entity)
+            {
+            }
+
+            protected override TableOperation AsTableOperation()
+            {
+                return TableOperation.InsertOrMerge(Entity);
+            }
+
+            public override EntityOperation Merge(EntityOperation other)
+            {
+                if (other is Insert)
+                    throw InvalidMerge(other);
+
+                if (other is Replace)
+                    throw InvalidMerge(other);
+
+                if (other is Delete)
+                    throw InvalidMerge(other);
+
+                if (other is InsertOrMerge)
+                    return other;
+
+                if (other is InsertOrReplace)
+                    throw InvalidMerge(other);
+
+                throw new InvalidOperationException("Unsupported operation type: " + other.GetType());
+            }
+        }
+
+        public class InsertOrReplace : EntityOperation
+        {
+            public InsertOrReplace(ITableEntity entity)
+                : base(entity)
+            {
+            }
+
+            protected override TableOperation AsTableOperation()
+            {
+                return TableOperation.InsertOrReplace(Entity);
+            }
+
+            public override EntityOperation Merge(EntityOperation other)
+            {
+                if (other is Insert)
+                    throw InvalidMerge(other);
+
+                if (other is Replace)
+                    throw InvalidMerge(other);
+
+                if (other is Delete)
+                    throw InvalidMerge(other);
+
+                if (other is InsertOrMerge)
+                    throw InvalidMerge(other);
+
+                if (other is InsertOrReplace)
+                    return other;
+
                 throw new InvalidOperationException("Unsupported operation type: " + other.GetType());
             }
         }
 
         class Null : EntityOperation
         {
-            internal Null() 
-                : base(null)  
-            {}
+            internal Null()
+                : base(null)
+            {
+            }
 
             protected override TableOperation AsTableOperation()
             {
@@ -132,25 +220,28 @@ namespace Streamstone
             {
                 if (other is Insert)
                     return other;
-                
+
                 if (other is Replace)
                     throw InvalidMerge(other);
 
                 if (other is Delete)
                     throw InvalidMerge(other);
 
-                throw new InvalidOperationException("Unsupported operation type: " + other.GetType());                   
+                if (other is InsertOrMerge)
+                    return other;
+
+                throw new InvalidOperationException("Unsupported operation type: " + other.GetType());
             }
 
             new static Exception InvalidMerge(EntityOperation other)
             {
                 var message = string.Format("Included 'Delete' operation interdifused with " +
                                             "preceding 'Insert' operation. " +
-                                            "'{0}' cannot be applied to NULL", 
-                                            other.GetType());
+                                            "'{0}' cannot be applied to NULL",
+                    other.GetType());
 
                 return new InvalidOperationException(message);
             }
-        }        
+        }
     }
 }

--- a/Source/Streamstone/Include.cs
+++ b/Source/Streamstone/Include.cs
@@ -23,7 +23,13 @@ namespace Streamstone
         /// <summary>
         /// The delete operation
         /// </summary>
-        Delete
+        Delete,
+
+        /// <summary>
+        /// The insert or merge operation
+        /// </summary>
+        InsertOrMerge,
+        InsertOrReplace
     }
 
     /// <summary>
@@ -66,7 +72,31 @@ namespace Streamstone
             Requires.NotNull(entity, "entity");
             return new Include(IncludeType.Delete, new EntityOperation.Delete(entity));
         }
- 
+
+        /// <summary>
+        /// Inserts or merges the specified entity.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns>A new instance of <see cref="Include"/> class</returns>
+        /// <exception cref="ArgumentNullException">If given <paramref name="entity"/> is <c>null</c>.</exception>
+        public static Include InsertOrMerge(ITableEntity entity)
+        {
+            Requires.NotNull(entity, "entity");
+            return new Include(IncludeType.InsertOrMerge, new EntityOperation.InsertOrMerge(entity));
+        }
+
+        /// <summary>
+        /// Inserts or replace the specified entity.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns>A new instance of <see cref="Include"/> class</returns>
+        /// <exception cref="ArgumentNullException">If given <paramref name="entity"/> is <c>null</c>.</exception>
+        public static Include InsertOrReplace(ITableEntity entity)
+        {
+            Requires.NotNull(entity, "entity");
+            return new Include(IncludeType.InsertOrReplace, new EntityOperation.InsertOrReplace(entity));
+        }
+
         Include(IncludeType type, EntityOperation operation)
         {
             Type = type;

--- a/Source/Streamstone/Include.cs
+++ b/Source/Streamstone/Include.cs
@@ -29,6 +29,10 @@ namespace Streamstone
         /// The insert or merge operation
         /// </summary>
         InsertOrMerge,
+
+        /// <summary>
+        /// The insert or replace operation
+        /// </summary>
         InsertOrReplace
     }
 


### PR DESCRIPTION
This PR introduces the `InsertOrMerge` operation. This is required for my approach to implement `from $all` semantics (#24). I can't promise that it will be done soon, nor that I'll be able to provided within a small reusable component though :) Anyway, being able to use this powerful operation could be an enabler for various scenario.
Could you review it @yevhen ? I hope I applied semantics of `Merge` operation correctly.
