### PR TITLE
[WIP] Support netstandard1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ obj/
 *.debug.css
 *.sln.ide/
 _ReSharper*
+.vs/
 
 #ignore certain folders
 /Output/

--- a/Source.vNext/Example/Example.csproj
+++ b/Source.vNext/Example/Example.csproj
@@ -1,0 +1,31 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wpa81+wp8</PackageTargetFallback>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Source\Example\**\*.cs" Exclude="..\..\Source\Example\Properties\*.cs;..\..\Example\Streamstone\obj\**\*.cs;..\..\Source\Example\bin\**\*.cs;" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>1.0.0-alpha-20161104-2</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="WindowsAzure.Storage">
+      <Version>7.2.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Streamstone\Streamstone.csproj" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Source.vNext/Streamstone.Tests/Streamstone.Tests.csproj
+++ b/Source.vNext/Streamstone.Tests/Streamstone.Tests.csproj
@@ -1,0 +1,100 @@
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup Label="Configuration">
+    <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
+    <RootNamespace>Streamstone.Tests</RootNamespace>
+    <AssemblyName>Streamstone.Tests</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>1.0.0-alpha-20161104-2</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="WindowsAzure.Storage">
+      <Version>7.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit">
+      <Version>3.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="ExpectedObjects">
+      <Version>1.2.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Streamstone\Streamstone.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Source\Streamstone.Tests\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Checking_stream_exists.cs">
+      <Link>Scenarios\Checking_stream_exists.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Custom_event_properties.cs">
+      <Link>Scenarios\Custom_event_properties.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Custom_stream_properties.cs">
+      <Link>Scenarios\Custom_stream_properties.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Including_additional_entities.cs">
+      <Link>Scenarios\Including_additional_entities.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Opening_stream.cs">
+      <Link>Scenarios\Opening_stream.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Provisioning_stream.cs">
+      <Link>Scenarios\Provisioning_stream.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Reading_from_stream.cs">
+      <Link>Scenarios\Reading_from_stream.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Setting_stream_properties.cs">
+      <Link>Scenarios\Setting_stream_properties.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Sharding_function.cs">
+      <Link>Scenarios\Sharding_function.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Tracking_entity_changes.cs">
+      <Link>Scenarios\Tracking_entity_changes.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Virtual_partitions.cs">
+      <Link>Scenarios\Virtual_partitions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Scenarios\Writing_to_stream.cs">
+      <Link>Scenarios\Writing_to_stream.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Api.cs">
+      <Link>Api.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Model.cs">
+      <Link>Model.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Tests\Storage.cs">
+      <Link>Storage.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Source.vNext/Streamstone/Streamstone.csproj
+++ b/Source.vNext/Streamstone/Streamstone.csproj
@@ -1,0 +1,42 @@
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <PropertyGroup Label="Configuration">
+    <DefineConstants>NETSTANDARD;NETSTANDARD_TODO</DefineConstants>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wpa81+wp8</PackageTargetFallback>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Source\Product.cs">
+      <Link>Properties\Product.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone.Version.cs;">
+      <Link>Properties\Streamstone.Version.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Source\Streamstone\**\*.cs" Exclude="..\..\Source\Streamstone\Properties\*.cs;..\..\Source\Streamstone\obj\**\*.cs;..\..\Source\Streamstone\bin\**\*.cs;" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>1.0.0-alpha-20161104-2</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NETStandard.Library">
+      <Version>1.6.1</Version>
+    </PackageReference>
+    <PackageReference Include="WindowsAzure.Storage">
+      <Version>7.2.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Source/Example/Program.cs
+++ b/Source/Example/Program.cs
@@ -55,8 +55,8 @@ namespace Example
                 .CreateCloudTableClient()
                 .GetTableReference("Example");
 
-            table.DeleteIfExists();
-            table.CreateIfNotExists();
+            table.DeleteIfExistsAsync().Wait();
+            table.CreateIfNotExistsAsync().Wait();
 
             return table;
         }

--- a/Source/Streamstone.Tests/Scenarios/Opening_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Opening_stream.cs
@@ -27,10 +27,10 @@ namespace Streamstone.Scenarios
         }
         
         [Test]
-        [ExpectedException(typeof(StreamNotFoundException))]
-        public async void When_stream_does_not_exist()
+        //[ExpectedException(typeof(StreamNotFoundException))]
+        public void When_stream_does_not_exist()
         {
-            await Stream.OpenAsync(partition);
+            Assert.ThrowsAsync<StreamNotFoundException>(async ()=> await Stream.OpenAsync(partition));
         }
 
         [Test]

--- a/Source/Streamstone.Tests/Scenarios/Reading_from_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Reading_from_stream.cs
@@ -32,10 +32,10 @@ namespace Streamstone.Scenarios
         }
 
         [Test]
-        [ExpectedException(typeof(StreamNotFoundException))]
-        public async void When_stream_doesnt_exist()
+        //[ExpectedException(typeof(StreamNotFoundException))]
+        public void When_stream_doesnt_exist()
         {
-            await Stream.ReadAsync<TestEventEntity>(partition);
+            Assert.ThrowsAsync<StreamNotFoundException>(async () => await Stream.ReadAsync<TestEventEntity>(partition));
         }
 
         [Test]

--- a/Source/Streamstone.Tests/Scenarios/Tracking_entity_changes.cs
+++ b/Source/Streamstone.Tests/Scenarios/Tracking_entity_changes.cs
@@ -254,7 +254,7 @@ namespace Streamstone.Scenarios
                 Stream.Write(stream, events));
 
             Assert.That(exception,
-                Has.Message.ContainsSubstring("cannot be followed by"));
+                Has.Message.Contains("cannot be followed by"));
         }
                 
         [Test]
@@ -309,7 +309,7 @@ namespace Streamstone.Scenarios
                 Stream.Write(stream, events));
 
             Assert.That(exception,
-                Has.Message.ContainsSubstring("cannot be followed by"));
+                Has.Message.Contains("cannot be followed by"));
         }
 
         [Test]
@@ -390,7 +390,7 @@ namespace Streamstone.Scenarios
                 Stream.Write(stream, events));
 
             Assert.That(exception,
-                Has.Message.ContainsSubstring("cannot be followed by"));
+                Has.Message.Contains("cannot be followed by"));
         }
         
         [Test]
@@ -408,7 +408,7 @@ namespace Streamstone.Scenarios
                 Stream.Write(stream, events));
 
             Assert.That(exception,
-                Has.Message.ContainsSubstring("cannot be followed by"));
+                Has.Message.Contains("cannot be followed by"));
         }
 
         /********* NULL followed by XXX ************/
@@ -449,7 +449,7 @@ namespace Streamstone.Scenarios
                 Stream.Write(stream, events));
 
             Assert.That(exception,
-                Has.Message.ContainsSubstring("cannot be applied to NULL"));
+                Has.Message.Contains("cannot be applied to NULL"));
         }        
         
         [Test]
@@ -469,7 +469,7 @@ namespace Streamstone.Scenarios
                 Stream.Write(stream, events));
 
             Assert.That(exception,
-                Has.Message.ContainsSubstring("cannot be applied to NULL"));
+                Has.Message.Contains("cannot be applied to NULL"));
         }
 
         /********* Insert-Or-Merge or Insert-Or-Replace followed by XXX ************/
@@ -572,7 +572,7 @@ namespace Streamstone.Scenarios
             Assert.That(stored.AdditionalData, Is.EqualTo("zzz"));
         }
 
-        public static IEnumerable<ITestCaseData> GetThrowingOperationsForInsertOrMergeOrReplace()
+        public static IEnumerable<TestCaseData> GetThrowingOperationsForInsertOrMergeOrReplace()
         {
             var entity = new TestEntity(EntityRowKey);
             var firstIncludeProducers = new Func<ITableEntity, Include>[] {Include.Insert, Include.Delete, Include.Replace};

--- a/Source/Streamstone/Extensions.cs
+++ b/Source/Streamstone/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -25,6 +24,7 @@ namespace Streamstone
         public static Exception PreserveStackTrace(this Exception ex)
         {
             var remoteStackTraceString = typeof(Exception)
+                .GetTypeInfo()
                 .GetField("_remoteStackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);
 
             Debug.Assert(remoteStackTraceString != null);

--- a/Source/Streamstone/PropertyMap.cs
+++ b/Source/Streamstone/PropertyMap.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
+using System.Reflection;
 
 namespace Streamstone
 {
@@ -98,7 +99,7 @@ namespace Streamstone
         {
             Requires.NotNull(obj, "obj");
 
-            return from property in obj.GetType().GetProperties() 
+            return from property in obj.GetType().GetTypeInfo().GetProperties() 
                    let key = property.Name 
                    let value = property.GetValue(obj, noargs) 
                    select ToKeyValuePair(key, value, property.PropertyType);

--- a/Source/Streamstone/StreamEntity.cs
+++ b/Source/Streamstone/StreamEntity.cs
@@ -50,7 +50,7 @@ namespace Streamstone
                 RowKey = entity.RowKey,
                 ETag = entity.ETag,
                 Timestamp = entity.Timestamp,
-                Version = (int)entity["Version"].PropertyAsObject,
+                Version = (int)entity.Properties["Version"].PropertyAsObject,
                 Properties = StreamProperties.From(entity)
             };
         }

--- a/Streamstone.vNext.sln
+++ b/Streamstone.vNext.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.25914.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Streamstone", "Source.vNext\Streamstone\Streamstone.csproj", "{BF652556-8225-4014-8AE5-83965276DFD0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Streamstone.Tests", "Source.vNext\Streamstone.Tests\Streamstone.Tests.csproj", "{EACB9715-D12A-4516-B1D8-58319A5928A5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example", "Source.vNext\Example\Example.csproj", "{1E32E72F-9371-4A62-9C12-6371A7657C85}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BF652556-8225-4014-8AE5-83965276DFD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF652556-8225-4014-8AE5-83965276DFD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF652556-8225-4014-8AE5-83965276DFD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF652556-8225-4014-8AE5-83965276DFD0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EACB9715-D12A-4516-B1D8-58319A5928A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EACB9715-D12A-4516-B1D8-58319A5928A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EACB9715-D12A-4516-B1D8-58319A5928A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EACB9715-D12A-4516-B1D8-58319A5928A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E32E72F-9371-4A62-9C12-6371A7657C85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E32E72F-9371-4A62-9C12-6371A7657C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E32E72F-9371-4A62-9C12-6371A7657C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E32E72F-9371-4A62-9C12-6371A7657C85}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This is PR try to make Streamstone a `netstandard1.5` library so it can run in .Net Core.

The approach taken is basically the same we did in Orleans. 

For now, I created a new solution and replicated the 3 projects in it but using links to the files in the current directories just to facilitate the changes in it.

So, major changes:

1. In `netstandard` version of `WindowsAzure.Storage` there is no sync methods anymore, so whenever I saw a sync method, I replaced with the `XXXAsync()` related version. **suggestion**: I would remove all the Sync methods from the SS APIs and expose only the async ones and let the user call `.Wait()` or `.Result` in it.
2. The `Example` project is now a .Net Core console app -> We can multitarget it in case we really need but I guess it is not necessary
3. Some usages of `GetType().SomethingElse` where replaced to `GetType().GetTypeInfo().SomethingElse` since many methods were moved there.
4. I borrowed from #28 PR the `lambda -> string` queries since they are all good. Thanks @chrissimmons for already started that work.
5. The `Streastone` project is now a `netstandard1.5` project.
6. The test project is targeting `net462`. The reason for that, is that NUnit does not work with `dotnet` CLI yet and there is no estimated date to do so. I think the code on SS is very lean and simple, so at least for now, the tests running only on `net462` should be OK since there is no `forking` or `#if` whatsoever inside the code, so when NUnit got support to it, we could just migrate it.
7. NUnit was migrated to the latest version otherwise, it wouldn't be able to run tests on VS2017.

I need some help with NUnit just to make it detect the tests on VS TestExplorer and @aprooks will have a look in it later on. 

Besides that, the `Example` app run perfectly, so I appreciate @yevhen  and the others if I can have a review here.

![image](https://cloud.githubusercontent.com/assets/4714040/20910313/ea71746c-bb47-11e6-97a2-6e03f5aab943.png)

Once you guys give an OK, I would revert/reset the changes at the PR and apply them to the main solution/projects, update the build scripts along with the .nuspec, and push the updates here.

Thanks! Looking forward to use SS in .Net Core with Orleans ASAP!

💃 

**PS**: Please note that appveyor build *will* fail. It will only pass once I update the main solution/project and the build scripts.