### PR TITLE
Add .NET 4.6 support

### DIFF
--- a/Source/Streamstone/Streamstone.csproj
+++ b/Source/Streamstone/Streamstone.csproj
@@ -1,8 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup>
     <LangVersion>7.1</LangVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>Yevhen Bobrov</Authors>
     <PackageProjectUrl>http://github.com/yevhen/Streamstone</PackageProjectUrl>

--- a/Source/Streamstone/Streamstone.nuspec
+++ b/Source/Streamstone/Streamstone.nuspec
@@ -16,11 +16,17 @@
         <dependency id="NETStandard.Library" version="2.0.0" exclude="Build,Analyzers" />
         <dependency id="WindowsAzure.Storage" version="8.3.0" exclude="Build,Analyzers" />
       </group>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="WindowsAzure.Storage" version="8.3.0" exclude="Build,Analyzers" />
+      </group>
     </dependencies>
   </metadata>
   <files>
     <file src="netstandard2.0\Streamstone.dll" target="lib/netstandard2.0" />
     <file src="netstandard2.0\Streamstone.pdb" target="lib/netstandard2.0" />
     <file src="netstandard2.0\Streamstone.xml" target="lib/netstandard2.0" />
+    <file src="net46\Streamstone.dll" target="lib/net46" />
+    <file src="net46\Streamstone.pdb" target="lib/net46" />
+    <file src="net46\Streamstone.xml" target="lib/net46" />
   </files>
 </package>


### PR DESCRIPTION
When the package has been updated in the solution form the version 1.* to 2.0.0 I found the only .NET Standard 2.0 is supported thus I've discovered lots of .NET Core SDK dependencies been conflicting with existing .NET 4.6.1 dependencies.  

I've added `net46` target framework explicitly to the release build and to the result package.
