### PR TITLE
Migrates from WindowsAzure.Storage to Microsoft.Azure.Cosmos.Table

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,8 @@
         <ExpectedObjectsVersion>2.3.4</ExpectedObjectsVersion>
 
         <!-- 3rd party packages -->
-        <WindowsAzureStorageVersion>8.6.0</WindowsAzureStorageVersion>
+        <MicrosoftAzureCosmosTableVersion>1.0.0</MicrosoftAzureCosmosTableVersion>
+        <NewtonsoftJsonBson>1.0.2</NewtonsoftJsonBson>
 
         <!-- Tooling related packages -->
         <SourceLinkVersion>2.7.6</SourceLinkVersion>

--- a/Source/Example/Example.csproj
+++ b/Source/Example/Example.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,10 @@
     <TargetFramework>$(ConsoleProjectTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="$(NewtonsoftJsonBson)" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Streamstone\Streamstone.csproj" />

--- a/Source/Example/Program.cs
+++ b/Source/Example/Program.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Example
 {

--- a/Source/Example/Scenario.cs
+++ b/Source/Example/Scenario.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Table;
+
+using Microsoft.Azure.Cosmos.Table;
 using Streamstone;
 
 namespace Example

--- a/Source/Example/Scenarios/S04_Write_to_stream.cs
+++ b/Source/Example/Scenarios/S04_Write_to_stream.cs
@@ -116,7 +116,7 @@ namespace Example.Scenarios
         {
             var stream = new System.IO.MemoryStream();
             
-            using (var writer = new BsonWriter(stream))
+            using (var writer = new BsonDataWriter(stream))
             {
                 var serializer = new JsonSerializer();
                 serializer.Serialize(writer, data);

--- a/Source/Example/Scenarios/S06_Include_additional_entities.cs
+++ b/Source/Example/Scenarios/S06_Include_additional_entities.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using Newtonsoft.Json;
-using Microsoft.WindowsAzure.Storage.Table;
 
 using Streamstone;
 

--- a/Source/Example/Scenarios/S07_Custom_stream_metadata.cs
+++ b/Source/Example/Scenarios/S07_Custom_stream_metadata.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 using Streamstone;
 
 namespace Example.Scenarios

--- a/Source/Example/Scenarios/S10_Stream_directory.cs
+++ b/Source/Example/Scenarios/S10_Stream_directory.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using Streamstone;
 using Streamstone.Utility;
 
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Example.Scenarios
 {

--- a/Source/Example/Scenarios/S11_Sharding_streams.cs
+++ b/Source/Example/Scenarios/S11_Sharding_streams.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage;
+
+using Microsoft.Azure.Cosmos.Table;
 
 using Streamstone;
 

--- a/Source/Streamstone.Tests/Model.cs
+++ b/Source/Streamstone.Tests/Model.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone.Tests/Scenarios/Checking_stream_exists.cs
+++ b/Source/Streamstone.Tests/Scenarios/Checking_stream_exists.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Cosmos_specifics.cs
+++ b/Source/Streamstone.Tests/Scenarios/Cosmos_specifics.cs
@@ -4,10 +4,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-using NUnit.Framework;
+using Microsoft.Azure.Cosmos.Table;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using NUnit.Framework;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Custom_event_properties.cs
+++ b/Source/Streamstone.Tests/Scenarios/Custom_event_properties.cs
@@ -3,8 +3,9 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Custom_stream_properties.cs
+++ b/Source/Streamstone.Tests/Scenarios/Custom_stream_properties.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Including_additional_entities.cs
+++ b/Source/Streamstone.Tests/Scenarios/Including_additional_entities.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Opening_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Opening_stream.cs
@@ -2,8 +2,9 @@
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Provisioning_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Provisioning_stream.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using ExpectedObjects;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Reading_from_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Reading_from_stream.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Setting_stream_properties.cs
+++ b/Source/Streamstone.Tests/Scenarios/Setting_stream_properties.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using ExpectedObjects;
 using NUnit.Framework;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Tracking_entity_changes.cs
+++ b/Source/Streamstone.Tests/Scenarios/Tracking_entity_changes.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
-
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Virtual_partitions.cs
+++ b/Source/Streamstone.Tests/Scenarios/Virtual_partitions.cs
@@ -3,8 +3,9 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using Microsoft.Azure.Cosmos.Table;
+
 using NUnit.Framework;
-using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Scenarios/Writing_to_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Writing_to_stream.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using ExpectedObjects;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone.Scenarios
 {

--- a/Source/Streamstone.Tests/Storage.cs
+++ b/Source/Streamstone.Tests/Storage.cs
@@ -4,8 +4,7 @@ using System.Linq;
 
 using ExpectedObjects;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/EntityOperation.cs
+++ b/Source/Streamstone/EntityOperation.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/EventEntity.cs
+++ b/Source/Streamstone/EventEntity.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/EventIdEntity.cs
+++ b/Source/Streamstone/EventIdEntity.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/EventProperties.cs
+++ b/Source/Streamstone/EventProperties.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/Exceptions.cs
+++ b/Source/Streamstone/Exceptions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Text;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/Include.cs
+++ b/Source/Streamstone/Include.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using Microsoft.WindowsAzure.Storage.Table;
+
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/Partition.cs
+++ b/Source/Streamstone/Partition.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/PropertyMap.cs
+++ b/Source/Streamstone/PropertyMap.cs
@@ -3,9 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
 using System.Reflection;
+
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/Stream.Api.cs
+++ b/Source/Streamstone/Stream.Api.cs
@@ -3,8 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/Stream.Operations.cs
+++ b/Source/Streamstone/Stream.Operations.cs
@@ -6,8 +6,7 @@ using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/StreamEntity.cs
+++ b/Source/Streamstone/StreamEntity.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/StreamProperties.cs
+++ b/Source/Streamstone/StreamProperties.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/StreamWriteResult.cs
+++ b/Source/Streamstone/StreamWriteResult.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {

--- a/Source/Streamstone/Streamstone.csproj
+++ b/Source/Streamstone/Streamstone.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -10,7 +10,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DocumentationFile>$(OutDir)\Streamstone.xml</DocumentationFile>
-    <TargetFrameworks>$(LibProjectTargetFramework);net46</TargetFrameworks>
+    <TargetFrameworks>$(LibProjectTargetFramework);net47</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="$(WindowsAzureStorageVersion)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="$(MicrosoftAzureCosmosTableVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Source/Streamstone/Utility.cs
+++ b/Source/Streamstone/Utility.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
-using Microsoft.WindowsAzure.Storage.Table;
+
+using Microsoft.Azure.Cosmos.Table;
 
 namespace Streamstone
 {


### PR DESCRIPTION
As of version 9.4.0, the WindowsAzure.Storage library has been split into multiple parts and replaced. In this case, we need to replace it with Microsoft.Azure.Cosmos.Table.