### PR TITLE
Trim error message about duplicate/conflicting entities before parsing it

### DIFF
--- a/Source/Streamstone.Tests/Scenarios/Cosmos_specifics.cs
+++ b/Source/Streamstone.Tests/Scenarios/Cosmos_specifics.cs
@@ -69,6 +69,24 @@ namespace Streamstone.Scenarios
             }));
         }
 
+        [Test]
+        public void When_writing_duplicate_event()
+        {
+            var partition = new Partition(table, "test-cosmos-dupes");
+            var stream = new Stream(partition);
+
+            partition.InsertEventIdEntities("e1", "e2");
+            partition.CaptureContents(contents =>
+            {
+                var duplicate = new EventData(EventId.From("e2"));
+
+                Assert.ThrowsAsync<DuplicateEventException>(
+                    async () => await Stream.WriteAsync(stream, new EventData(EventId.From("e3")), duplicate));
+
+                contents.AssertNothingChanged();
+            });
+        }
+
         static EventData CreateEvent(int num)
         {
             var properties = new Dictionary<string, EntityProperty>

--- a/Source/Streamstone/Stream.Operations.cs
+++ b/Source/Streamstone/Stream.Operations.cs
@@ -266,7 +266,7 @@ namespace Streamstone
 
                 static int ParseConflictingEntityPosition(StorageExtendedErrorInformation error)
                 {
-                    var lines = error.ErrorMessage.Split('\n');
+                    var lines = error.ErrorMessage.Trim().Split('\n');
                     if (lines.Length != 3)
                         throw UnexpectedStorageResponseException.ConflictExceptionMessageShouldHaveExactlyThreeLines(error);
 


### PR DESCRIPTION
Because CosmosDB adds a trailing new-line onto the end that Table Storage does not. Fixes #56.