### PR TITLE
Fix NuGet pack deprecation warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,18 +6,18 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Configurations>Debug;Release</Configurations>    
+        <Configurations>Debug;Release</Configurations>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
 
     <!-- Set common properties regarding assembly information and nuget packages -->
-    <PropertyGroup>    
+    <PropertyGroup>
         <Authors>Yevhen Bobrov</Authors>
         <Product>Streamstone</Product>
         <Copyright>since 2016 © Yevhen Bobrov. All rights reserved.</Copyright>
-        <PackageLicenseUrl>http://github.com/yevhen/Streamstone/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageProjectUrl>http://github.com/yevhen/Streamstone</PackageProjectUrl>
-        <PackageIconUrl>https://github.com/yevhen/Streamstone/raw/master/Logo.png</PackageIconUrl>
+        <PackageIcon>Logo.png</PackageIcon>
         <PackageTags>event store eventstore eventsourcing event-sourcing CQRS azure table storage stream</PackageTags>
         <PackageReleaseNotes></PackageReleaseNotes>
         <RepositoryUrl>https://github.com/yevhen/Streamstone</RepositoryUrl>
@@ -25,6 +25,11 @@
         <IncludeSymbols>true</IncludeSymbols>
         <IncludeSource>true</IncludeSource>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="$(SourceRoot)Logo.png" Pack="true" Visible="false" PackagePath="/" />
+        <None Include="$(SourceRoot)LICENSE" Pack="true" Visible="false" PackagePath="/" />
+    </ItemGroup>
 
     <!-- Common compile parameters -->
     <PropertyGroup>
@@ -50,7 +55,7 @@
 
     <!-- Shared Package Versions -->
     <PropertyGroup>
-    	
+
         <!-- Testing packages -->
         <NUnitVersion>3.10.0</NUnitVersion>
         <NUnit3TestAdapterVersion>3.10.0</NUnit3TestAdapterVersion>
@@ -112,6 +117,6 @@
                 <GitHeadSha Condition="'$(HeadFileContent)' != '' AND '$(RefPath)' == ''">$(HeadFileContent)</GitHeadSha>
             </PropertyGroup>
         </Otherwise>
-    </Choose>        
+    </Choose>
 
 </Project>


### PR DESCRIPTION
Low priority issue... This replaces the deprecated [`PackageLicenseUrl`](https://docs.microsoft.com/en-us/nuget/reference/nuspec#licenseurl) and [`PackageIconUrl`](https://docs.microsoft.com/en-us/nuget/reference/nuspec#iconurl) configuration elements with suggested replacements and embedded files.