### PR TITLE
Restore conflicting event Id on DuplicateEventException

### DIFF
--- a/Source/Example/Scenarios/S09_Handling_duplicates.cs
+++ b/Source/Example/Scenarios/S09_Handling_duplicates.cs
@@ -21,10 +21,11 @@ namespace Example.Scenarios
 
                 await Stream.WriteAsync(result.Stream, events);
             }
-            catch (DuplicateEventException)
+            catch (DuplicateEventException e)
             {
                 Console.WriteLine("Duplicate event detection is based on ID of the event.");
                 Console.WriteLine("An ID of conflicting event will be reported back as a property of DuplicateEventException.");
+                Console.WriteLine("Here the conflicting event is: {0}", e.Id);
                 Console.WriteLine("The caller can use this information to remove conflicting event from the batch and retry (or cancel)");
             }
         }

--- a/Source/Streamstone.Tests/Scenarios/Writing_to_stream.cs
+++ b/Source/Streamstone.Tests/Scenarios/Writing_to_stream.cs
@@ -80,10 +80,12 @@ namespace Streamstone.Scenarios
             {
                 var duplicate = CreateEvent("e2");
 
-                Assert.ThrowsAsync<DuplicateEventException>(
+                var exception = Assert.ThrowsAsync<DuplicateEventException>(
                     async () => await Stream.WriteAsync(stream, CreateEvent("e3"), duplicate));
 
-                contents.AssertNothingChanged();  
+                Assert.That(exception.Id, Is.EqualTo("e2"));
+
+                contents.AssertNothingChanged();
             });
         }
 

--- a/Source/Streamstone/Exceptions.cs
+++ b/Source/Streamstone/Exceptions.cs
@@ -52,11 +52,17 @@ namespace Streamstone
         /// </summary>
         public readonly Partition Partition;
 
-        internal DuplicateEventException(Partition partition)
-            : base("Found existing event in partition '{1}' which resides in '{0}' table located at {2}",
-                   partition.Table, partition, partition.Table.Uri)
+        /// <summary>
+        /// The id of duplicate event
+        /// </summary>
+        public readonly string Id;
+
+        internal DuplicateEventException(Partition partition, string id)
+            : base("Found existing event with id '{3}' in partition '{1}' which resides in '{0}' table located at {2}",
+                   partition.Table, partition, partition.Table.Uri, id)
         {
             Partition = partition;
+            Id = id;
         }
     }
 

--- a/Source/Streamstone/Stream.Operations.cs
+++ b/Source/Streamstone/Stream.Operations.cs
@@ -262,8 +262,11 @@ namespace Streamstone
                     if (conflicting.RowKey == stream.RowKey)
                         throw ConcurrencyConflictException.StreamChangedOrExists(partition);
 
-                    if (conflicting.RowKey.StartsWith(EventIdEntity.RowKeyPrefix))
-                        throw new DuplicateEventException(partition);
+                    if (conflicting.RowKey.StartsWith(partition.RowKeyPrefix + EventIdEntity.RowKeyPrefix))
+                    {
+                        var duplicateId = conflicting.RowKey.Substring(partition.RowKeyPrefix.Length + EventIdEntity.RowKeyPrefix.Length);
+                        throw new DuplicateEventException(partition, duplicateId);
+                    }
 
                     if (conflicting.RowKey.StartsWith(EventEntity.RowKeyPrefix))
                         throw ConcurrencyConflictException.EventVersionExists(partition);


### PR DESCRIPTION
Recover the ID from the failed transaction action's RowKey so callers can identify which event in the batch conflicted, as the public API documented before Azure.Data.Tables migration.